### PR TITLE
Return early if PlayerCommandPreprocessEvent already cancelled.

### DIFF
--- a/src/main/java/me/nik/resourceworld/modules/impl/DisabledCommands.java
+++ b/src/main/java/me/nik/resourceworld/modules/impl/DisabledCommands.java
@@ -22,7 +22,9 @@ public class DisabledCommands extends ListenerModule {
 
     @EventHandler(priority = EventPriority.HIGHEST)
     public void disableWorldCommands(PlayerCommandPreprocessEvent e) {
-
+        
+        if(e.isCancelled()) return;
+        
         Player player = e.getPlayer();
 
         if (player.hasPermission(Permissions.ADMIN.getPermission()) || e.getMessage().equals("/")) return;


### PR DESCRIPTION
Fixes issue of the resource world `disabled_command` message being sent to the user if the command was disabled/prevented by another plugin (e.g. skript's command system).

<img width="990" height="68" alt="image" src="https://github.com/user-attachments/assets/81a36d40-6e80-4c06-93f7-ecc34fd7b02b" />
